### PR TITLE
refactor: edit replies when encountering command errors.

### DIFF
--- a/main.js
+++ b/main.js
@@ -289,7 +289,7 @@ bot.on('interactionCreate', async interaction => {
 		catch (err) {
 			console.log(`[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] ${getLocale(defaultLocale, 'LOG_CMD_ERROR', interaction.commandName)}`);
 			console.error(err);
-			await interaction.reply({
+			await interaction.editReply({
 				embeds: [
 					new MessageEmbed()
 						.setDescription(getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'DISCORD_CMD_ERROR'))


### PR DESCRIPTION
This is to minimize the chances of the Error:[INTERACTION_ALREADY_REPLIED] that causes a crash to Quaver whenever a command encounters an error. I know this could've been done better, please give some thoughts into it.