### PR TITLE
refactor: use shuttingDown when exiting

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,8 @@ const rl = readline.createInterface({
 rl.on('line', line => {
 	switch (line.split(' ')[0]) {
 		case 'exit':
-			process.exit(0);
+			process.exitCode = 0;
+			shuttingDown('exit');
 			break;
 		case 'sessions':
 			if (!startup) {

--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ const rl = readline.createInterface({
 rl.on('line', line => {
 	switch (line.split(' ')[0]) {
 		case 'exit':
-			process.exitCode = 0;
 			shuttingDown('exit');
 			break;
 		case 'sessions':


### PR DESCRIPTION
Context:
https://discord.com/channels/906471497231630336/920107978760261663/950441345703637003

https://discord.com/channels/906471497231630336/920107978760261663/950458256030068787

Instead of exiting the process immediately, using shuttingDown would make the sending of `MUSIC_RESTART` when there's queues during exits consistent, at the same time the process will exit with success code 0 as well.

Prior to this, `MUSIC_RESTART` doesn't get sent to the player queue text channel consistently whenever `exit` is executed from the terminal.



