### PR TITLE
refactor: start stage only once

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -127,9 +127,6 @@ module.exports = {
 				});
 				return;
 			}
-			if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance) {
-				await interaction.member.voice.channel.createStageInstance({ topic: getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
-			}
 		}
 
 		const firstPosition = insert ? 1 : player.queue.tracks.length + 1;


### PR DESCRIPTION
Prior to this, Quaver starts and sets stage topic on stage channels twice if `/play` is used. Although, there is no issue in functionality, I think this one is overlooked.
**Testing on current functionality (before this PR)**
> With console.logs
```
[Quaver] Connected to Discord! Logged in as ThatKid#6969.
[Quaver] Running version 3.3.1-next.1. For help, see https://github.com/ZapSquared/Quaver/issues.
[Quaver] Connected to Lavalink!
[G 906471497231630336 | U 250934589621665793] Processing command play
[G 906471497231630336 | U 250934589621665793] Executing command play
[Log] Set stage topic (/play)
[Log] Set stage topic (voiceStateUpdate)
```
**Suggestion**
I think it would be better to let voiceStateUpdate alone handle starting and setting the topic for stage channels.

With this, Quaver will now start and set a stage topic for stage channels only once with `/play`.

Also handles
- If Quaver is manually moved to an unstarted stage channel, Quaver will start and set a stage topic as expected.
- When `/play` (commands that starts a track) is used on a stage channel, Quaver will start and set a stage topic as expected. 

Suggest necessary changes for if this change conflicts with other things.