### PR TITLE
fix: add permission check on newState (fixes #127)

### DIFF
--- a/main.js
+++ b/main.js
@@ -554,7 +554,7 @@ bot.on('voiceStateUpdate', async (oldState, newState) => {
 				}
 				return;
 			}
-			// check for connect, speak permission for channel
+			// check for connect, speak permission for stage channel
 			const channel = player.queue.channel;
 			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 				await channel.send({

--- a/main.js
+++ b/main.js
@@ -554,6 +554,32 @@ bot.on('voiceStateUpdate', async (oldState, newState) => {
 				}
 				return;
 			}
+			// check for connect, speak permission for channel
+			const channel = player.queue.channel;
+			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+				await channel.send({
+					embeds: [
+						new MessageEmbed()
+							.setDescription(getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'DISCORD_BOT_MISSING_PERMISSIONS_BASIC'))
+							.setColor('DARK_RED'),
+					],
+				});
+				bot.music.destroyPlayer(player.guildId);
+				player.disconnect();
+				return;
+			}
+			if (newState.member?.voice.channel.type === 'GUILD_STAGE_VOICE' && !permissions.has(Permissions.STAGE_MODERATOR)) {
+				await channel.send({
+					embeds: [
+						new MessageEmbed()
+							.setDescription(getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'DISCORD_BOT_MISSING_PERMISSIONS_STAGE'))
+							.setColor('DARK_RED'),
+					],
+				});
+				bot.music.destroyPlayer(player.guildId);
+				player.disconnect();
+				return;
+			}
 			await newState.setSuppressed(false);
 			if (!newState.channel.stageInstance) {
 				await newState.channel.createStageInstance({ topic: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });


### PR DESCRIPTION
# Work in progress, #130 must be merged first.
This addresses permission checks on `voiceStateUpdate`

**Voice**
- If Quaver has insufficient permissions on voice channels:
   - Send message `DISCORD_BOT_MISSING_PERMISSIONS_BASIC` message to current text channel.
      - If the Quaver has insufficient permissions on text channels:
         - Do not send message.
- Disconnect from voice channel.

**Stage**
- If Quaver has insufficient permissions on stage channels:
   - Send message `DISCORD_BOT_MISSING_PERMISSIONS_BASIC`  to current text channel.
      - If the Quaver has insufficient permissions on text channels:
         - Do not send message.
- Disconnect from stage channel.


Any better alternatives, suggest the changes.

Fixes #127's potential unhandledRejection crash.
Adds a failsafe for #128 

While waiting for that new slash command feature, I think this one is ok for now.