### PR TITLE
fix: permission check on text channel (fixes #130)

### DIFF
--- a/main.js
+++ b/main.js
@@ -252,8 +252,8 @@ bot.on('interactionCreate', async interaction => {
 		}
 		const failedPermissions = { user: [], bot: [] };
 		const botChannelPerms = interaction.channel.permissionsFor(bot.user.id);
-		if (!botChannelPerms.has('VIEW_CHANNEL')) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
-		if (!botChannelPerms.has('SEND_MESSAGES')) { failedPermissions.bot.push(['SEND_MESSAGES']); }
+		if (!botChannelPerms.has('VIEW_CHANNEL')) { failedPermissions.bot.push('VIEW_CHANNEL'); }
+		if (!botChannelPerms.has('SEND_MESSAGES')) { failedPermissions.bot.push('SEND_MESSAGES'); }
 		for (const perm of command.permissions.user) {
 			if (!interaction.member.permissions.has(perm)) {
 				failedPermissions.user.push(perm);

--- a/main.js
+++ b/main.js
@@ -252,8 +252,8 @@ bot.on('interactionCreate', async interaction => {
 		}
 		const failedPermissions = { user: [], bot: [] };
 		const botChannelPerms = interaction.channel.permissionsFor(bot.user.id);
-		if (!botChannelPerms.has(['VIEW_CHANNEL'])) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
-		if (!botChannelPerms.has(['SEND_MESSAGES'])) { failedPermissions.bot.push(['SEND_MESSAGES']); }
+		if (!botChannelPerms.has('VIEW_CHANNEL')) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
+		if (!botChannelPerms.has('SEND_MESSAGES')) { failedPermissions.bot.push(['SEND_MESSAGES']); }
 		for (const perm of command.permissions.user) {
 			if (!interaction.member.permissions.has(perm)) {
 				failedPermissions.user.push(perm);

--- a/main.js
+++ b/main.js
@@ -251,6 +251,8 @@ bot.on('interactionCreate', async interaction => {
 			return;
 		}
 		const failedPermissions = { user: [], bot: [] };
+		if (!interaction.channel.permissionsFor(bot.user.id).has(['VIEW_CHANNEL'])) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
+		if (!interaction.channel.permissionsFor(bot.user.id).has(['SEND_MESSAGES'])) { failedPermissions.bot.push(['SEND_MESSAGES']); }
 		for (const perm of command.permissions.user) {
 			if (!interaction.member.permissions.has(perm)) {
 				failedPermissions.user.push(perm);

--- a/main.js
+++ b/main.js
@@ -251,8 +251,9 @@ bot.on('interactionCreate', async interaction => {
 			return;
 		}
 		const failedPermissions = { user: [], bot: [] };
-		if (!interaction.channel.permissionsFor(bot.user.id).has(['VIEW_CHANNEL'])) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
-		if (!interaction.channel.permissionsFor(bot.user.id).has(['SEND_MESSAGES'])) { failedPermissions.bot.push(['SEND_MESSAGES']); }
+		const botChannelPerms = interaction.channel.permissionsFor(bot.user.id);
+		if (!botChannelPerms.has(['VIEW_CHANNEL'])) { failedPermissions.bot.push(['VIEW_CHANNEL']); }
+		if (!botChannelPerms.has(['SEND_MESSAGES'])) { failedPermissions.bot.push(['SEND_MESSAGES']); }
 		for (const perm of command.permissions.user) {
 			if (!interaction.member.permissions.has(perm)) {
 				failedPermissions.user.push(perm);


### PR DESCRIPTION
### Notes to self: Conflicts must be resolved if one of the PRs gets merged.

Addresses permission issues on `interactionCreate`

With this
- Quaver will send the missing permissions of **the text channel it is trying to send to** in an ephemeral to the user.

`VIEW_CHANNEL` - Can't view the channel but can see messages, should prevent unwanted crashes etc.
`SEND_MESSAGES` - Can view the channel but can't send any messages.

If both checks fail, will push both checks to the user.

Fixes #130 completely.
Adds a failsafe for #128

Tried to make it take the least amount of lines possible, I still feel like this can be improved with the same functionality.

While waiting for that new slash command feature, I think this one is ok for now.