### PR TITLE
fix: handle already started stage error

### DIFF
--- a/main.js
+++ b/main.js
@@ -610,7 +610,12 @@ bot.on('voiceStateUpdate', async (oldState, newState) => {
 			}
 			await newState.setSuppressed(false);
 			if (!newState.channel.stageInstance) {
-				await newState.channel.createStageInstance({ topic: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
+				try {
+					await newState.channel.createStageInstance({ topic: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
+				}
+				catch (err) {
+					logger.error({ message: err, label: 'Quaver' });
+				}
 			}
 		}
 		// the new vc has no humans


### PR DESCRIPTION
Fixes #159

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
I chose try catch because Quaver is supposed to continue its supposed operation during error encounters from trying to start an already started stage.

I haven't thought of a way to prevent the error from happening but this will do for now.
