### PR TITLE
feat: lavalink reconnect options

### DIFF
--- a/main.js
+++ b/main.js
@@ -108,6 +108,10 @@ bot.music = new Node({
 		port: lavalink.port,
 		password: lavalink.password,
 		secure: !!lavalink.secure,
+		reconnect: {
+			delay: lavalink.reconnect.delay,
+			tries: lavalink.reconnect.tries,
+		},
 	},
 	sendGatewayPayload: (id, payload) => bot.guilds.cache.get(id)?.shard?.send(payload),
 });

--- a/settings.example.json
+++ b/settings.example.json
@@ -12,7 +12,7 @@
     "password": "youshallnotpass",
     "secure": false,
     "reconnect": {
-      "delay": 5000,
+      "delay": 3000,
       "tries": 5
     }
   },

--- a/settings.example.json
+++ b/settings.example.json
@@ -10,7 +10,11 @@
     "host": "localhost",
     "port": 12345,
     "password": "youshallnotpass",
-    "secure": false
+    "secure": false,
+    "reconnect": {
+      "delay": 5000,
+      "tries": 5
+    }
   },
   "spotify": {
     "client_id": "Paste Spotify Client ID here",


### PR DESCRIPTION
Closes #131

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Description
I chose reconnect delay as `5000` because this doesn't happen much often, but please suggest better value for this.
I chose reconnect tries as `5` times only as an example, I am waiting for suggestions for the default values for all of these.

For infinite amount of tries, use `-1`
