### PR TITLE
feat: shut down on caught lavalink error instead

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,9 +138,17 @@ bot.music.on('connect', () => {
 });
 
 bot.music.on('disconnect', () => {
+	// quaver is already shuttingDown, do not log
+	if (inprg === true) { return; }
 	logger.warn({ message: 'Disconnected.', label: 'Lavalink' });
-	logger.error({ message: 'Quaver is unable to resume after disconnecting from Lavalink and will now shut down gracefully to avoid issues.', label: 'Quaver' });
-	shuttingDown('exit');
+});
+
+bot.music.on('error', (err) => {
+	// quaver is already shuttingDown, do not log
+	if (inprg === true) { return; }
+	logger.error({ message: 'Encountered error while connecting to Lavalink.', label: 'Lavalink' });
+	// pass the an empty eventType with error message as err
+	shuttingDown('', err);
 });
 
 bot.music.on('queueFinish', queue => {

--- a/main.js
+++ b/main.js
@@ -147,7 +147,7 @@ bot.music.on('error', (err) => {
 	// quaver is already shuttingDown, do not log
 	if (inprg === true) { return; }
 	logger.error({ message: 'Encountered error while connecting to Lavalink.', label: 'Lavalink' });
-	// pass the an empty eventType with error message as err
+	// pass empty eventType with error message as err
 	shuttingDown('', err);
 });
 

--- a/main.js
+++ b/main.js
@@ -138,13 +138,13 @@ bot.music.on('connect', () => {
 });
 
 bot.music.on('disconnect', () => {
-	// quaver is already shuttingDown, do not log
+	// already shuttingDown, do not log
 	if (inprg === true) { return; }
 	logger.warn({ message: 'Disconnected.', label: 'Lavalink' });
 });
 
 bot.music.on('error', (err) => {
-	// quaver is already shuttingDown, do not log
+	// already shuttingDown, do not log
 	if (inprg === true) { return; }
 	logger.error({ message: 'Encountered error while connecting to Lavalink.', label: 'Lavalink' });
 	// pass empty eventType with error message as err

--- a/main.js
+++ b/main.js
@@ -144,8 +144,6 @@ bot.music.on('disconnect', () => {
 });
 
 bot.music.on('error', (err) => {
-	// already shuttingDown, do not log
-	if (inprg === true) { return; }
 	logger.error({ message: 'Encountered error while connecting to Lavalink.', label: 'Lavalink' });
 	// pass empty eventType with error message as err
 	shuttingDown('', err);

--- a/main.js
+++ b/main.js
@@ -142,14 +142,11 @@ bot.music.on('connect', () => {
 });
 
 bot.music.on('disconnect', () => {
-	// already shuttingDown, do not log
-	if (inprg === true) { return; }
 	logger.warn({ message: 'Disconnected.', label: 'Lavalink' });
 });
 
 bot.music.on('error', (err) => {
-	logger.error({ message: 'Encountered error while connecting to Lavalink.', label: 'Lavalink' });
-	// pass empty eventType with error message as err
+	logger.error({ message: 'An error occurred. Quaver will now shut down to prevent any further issues.', label: 'Lavalink' });
 	shuttingDown('', err);
 });
 

--- a/main.js
+++ b/main.js
@@ -145,7 +145,7 @@ bot.music.on('disconnect', () => {
 	logger.warn({ message: 'Disconnected.', label: 'Lavalink' });
 });
 
-bot.music.on('error', (err) => {
+bot.music.on('error', err => {
 	logger.error({ message: 'An error occurred. Quaver will now shut down to prevent any further issues.', label: 'Lavalink' });
 	shuttingDown('', err);
 });


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Description
Please describe the changes.

I let lavaclient's error listener to shutDown Quaver instead because it can produce errors for logging.
