### PR TITLE
refactor: rename variable startup to startUp

### DIFF
--- a/events/ready.js
+++ b/events/ready.js
@@ -5,8 +5,8 @@ module.exports = {
 	name: 'ready',
 	once: false,
 	async execute(client) {
-		const { startup, updateStartup } = require('../main.js');
-		if (!startup) {
+		const { startUp, updateStartup } = require('../main.js');
+		if (!startUp) {
 			logger.info({ message: `Connected. Logged in as ${client.user.tag}.`, label: 'Discord' });
 			logger.info({ message: `Running version ${version}. For help, see https://github.com/ZapSquared/Quaver/issues.`, label: 'Quaver' });
 			if (version.includes('-')) {

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ rl.on('line', line => {
 			shuttingDown('exit');
 			break;
 		case 'sessions':
-			if (!module.exports.startup) {
+			if (!module.exports.startUp) {
 				console.log('Quaver is not initialized yet.');
 				break;
 			}
@@ -32,7 +32,7 @@ rl.on('line', line => {
 			break;
 		}
 		case 'whitelist': {
-			if (!module.exports.startup) {
+			if (!module.exports.startUp) {
 				console.log('Quaver is not initialized yet.');
 				break;
 			}
@@ -96,7 +96,7 @@ async function shuttingDown(eventType, err) {
 	if (inProgress) return;
 	inProgress = true;
 	logger.info({ message: 'Shutting down...', label: 'Quaver' });
-	if (module.exports.startup) {
+	if (module.exports.startUp) {
 		logger.info({ message: 'Disconnecting from all guilds...', label: 'Quaver' });
 		for (const pair of bot.music.players) {
 			const player = pair[1];
@@ -180,7 +180,7 @@ bot.login(token);
 	process.on(eventType, err => shuttingDown(eventType, err));
 });
 
-module.exports.startup = false;
+module.exports.startUp = false;
 module.exports.updateStartup = () => {
-	module.exports.startup = true;
+	module.exports.startUp = true;
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

Rename variable `startup` to `startUp` for it to be consistent with other variables' names using camelCase naming convention.


