### PR TITLE
fix: missing args

### DIFF
--- a/commands/bind.js
+++ b/commands/bind.js
@@ -24,7 +24,7 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		const channel = interaction.options.getChannel('new_channel');
 		if (!channel.permissionsFor(interaction.client.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) {
-			await interaction.replyHandler.localeErrorReply('CMD_BIND_NO_PERMISSIONS');
+			await interaction.replyHandler.localeErrorReply('CMD_BIND_NO_PERMISSIONS', {}, channel.id);
 			return;
 		}
 		player.queue.channel = channel;


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

A check is missing arguments for a locale variable when sending its replyData.