### PR TITLE
fix: send to channel if reply message is deleted

### DIFF
--- a/classes/ReplyHandler.js
+++ b/classes/ReplyHandler.js
@@ -39,6 +39,9 @@ module.exports = class ReplyHandler {
 	 */
 	reply(data, embedExtras) {
 		const replyData = this.replyDataConstructor(data, embedExtras);
+		if (!this.interaction.message) {
+			return this.interaction.channel.send(replyData);
+		}
 		if (!this.interaction.replied && !this.interaction.deferred) {
 			if (!this.interaction.channel.permissionsFor(this.interaction.client.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) {
 				replyData.ephemeral = true;
@@ -58,6 +61,9 @@ module.exports = class ReplyHandler {
 	 */
 	error(data, embedExtras) {
 		const replyData = this.replyDataConstructor(data, embedExtras, true);
+		if (!this.interaction.message) {
+			return this.interaction.channel.send(replyData);
+		}
 		if (!this.interaction.replied && !this.interaction.deferred) {
 			replyData.ephemeral = true;
 			return this.interaction.reply(replyData);

--- a/classes/ReplyHandler.js
+++ b/classes/ReplyHandler.js
@@ -40,6 +40,9 @@ module.exports = class ReplyHandler {
 	reply(data, embedExtras) {
 		const replyData = this.replyDataConstructor(data, embedExtras);
 		if (!this.interaction.message) {
+			if (!this.interaction.channel.permissionsFor(this.interaction.client.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) {
+				return;
+			}
 			return this.interaction.channel.send(replyData);
 		}
 		if (!this.interaction.replied && !this.interaction.deferred) {


### PR DESCRIPTION
Fixes #167

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

`!interaction.message`
I added this for it to prevent crashes about replying to a message that doesn't exist.
Sends to channel instead.

**Tested?**
Yes.

If there are necessary changes to be done or better ways of implementing this, please, suggest.