### PR TITLE
fix: add a check to not push a null "current"

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ async function shuttingDown(eventType, err) {
 			const player = pair[1];
 			logger.info({ message: `[G ${player.guildId}] Disconnecting (restarting)`, label: 'Quaver' });
 			const fileBuffer = [];
-			if (player.queue.tracks.length > 0 || player.queue.current && (player.playing || player.paused)) {
+			if (player.queue.current && (player.playing || player.paused)) {
 				fileBuffer.push(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'CURRENT')}:`);
 				fileBuffer.push(player.queue.current.uri);
 				if (player.queue.tracks.length > 0) {

--- a/main.js
+++ b/main.js
@@ -105,10 +105,10 @@ async function shuttingDown(eventType, err) {
 			if (player.queue.current && (player.playing || player.paused)) {
 				fileBuffer.push(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'CURRENT')}:`);
 				fileBuffer.push(player.queue.current.uri);
-				if (player.queue.tracks.length > 0) {
-					fileBuffer.push(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'QUEUE')}:`);
-					fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
-				}
+			}
+			if (player.queue.tracks.length > 0) {
+				fileBuffer.push(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'QUEUE')}:`);
+				fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
 			}
 			player.musicHandler.disconnect();
 			const botChannelPerms = bot.guilds.cache.get(player.guildId).channels.cache.get(player.queue.channel.id).permissionsFor(bot.user.id);


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Adds a check so it will not try to push `null`, addresses the issue that makes Quaver not exit the process fully when shuttingDown on some conditions.

Particularly this https://github.com/ZapSquared/Quaver/issues/167#issuecomment-1087831820