### PR TITLE
feat(locales): update fil-PH locale

### DIFF
--- a/locales/fil-PH.json
+++ b/locales/fil-PH.json
@@ -21,7 +21,7 @@
   "MUSIC_STAGE_TOPIC": "Musika ni Quaver",
   "MUSIC_RESTART": "Nagre-restart si Quaver at madidiskonekta.",
   "MUSIC_RESTART_CRASH": "Nag-crash si Quaver at madidiskonekta.",
-  "MUSIC_RESTART_QUEUEDATA": "Ang iyong data ng queue ay naka-attach.",
+  "MUSIC_RESTART_QUEUEDATA": "Ang data ng iyong queue ay naka-attach.",
   "MUSIC_RESTART_SORRY": "Paumanhin para sa abalang naidulot.",
   "MUSIC_FILTERS_NOTE": "Maaaring tumagal ito ng ilang segundo bago mag-apply",
   "MUSIC_LIVE": "LIVE",

--- a/locales/fil-PH.json
+++ b/locales/fil-PH.json
@@ -1,6 +1,7 @@
 {
   "MUSIC_INACTIVITY": "Nadiskonekta mula sa kawalan ng aktibidad.",
   "MUSIC_INACTIVITY_WARNING": "Aalis ako <t:%1:R>.",
+  "MUSIC_TRACK_SKIPPED": "Nilaktawan ang **[%1](%2)** dahil may naganap na error: `%3`",
   "MUSIC_ALONE": "Nadiskonekta nang umalis ang lahat.",
   "MUSIC_ALONE_MOVED": "Nadiskonekta dahil walang tao sa target na channel.",
   "MUSIC_ALONE_WARNING": "Walang tao dito.",

--- a/locales/fil-PH.json
+++ b/locales/fil-PH.json
@@ -53,6 +53,7 @@
   "CMD_BASSBOOST_DISABLED": "Ang bass boost ay **naka-disable**",
   "CMD_BIND_DESCRIPTION": "Baguhin ang text channel na ginamit ni Quaver para awtomatikong magpadala ng mga mensahe.",
   "CMD_BIND_OPTION_CHANNEL": "Ito ang text channel na maba-bind.",
+  "CMD_BIND_NO_PERMISSIONS": "Wala akong sapat na mga permission sa <#%1>.",
   "CMD_BIND_SUCCESS": "Nakabind sa <#%1>",
   "CMD_CLEAR_DESCRIPTION": "I-clear ang queue.",
   "CMD_CLEAR_EMPTY": "Walang mga track sa queue na i-clear.",


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

Adds missing strings for fil-PH locale.