### PR TITLE
fix: check for permissions for voice channel

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -30,7 +30,7 @@ module.exports = {
 			// channel is a voice channel
 			if (newState.channel.type === 'GUILD_VOICE') {
 				// check for connect, speak permission for voice channel
-				const permissions =	bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
+				const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
 				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
 					player.musicHandler.disconnect();

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -27,6 +27,16 @@ module.exports = {
 				player.musicHandler.disconnect();
 				return;
 			}
+			// channel is a voice channel
+			if (newState.channel.type === 'GUILD_VOICE') {
+				// check for connect, speak permission for voice channel
+				const permissions =	bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
+				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+					player.musicHandler.disconnect();
+					return;
+				}
+			}
 			// channel is a stage channel, and bot is suppressed
 			// this also handles suppressing Quaver mid-track
 			if (newState.channel.type === 'GUILD_STAGE_VOICE' && newState.suppress) {


### PR DESCRIPTION
Fixes #182

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

This was supposed to come with #151
I added this check for Quaver to leave the voice channel if it lacks permissions to view the channel, connect, or speak in the voice channel.

As we all know, try catch catches the error "Missing Permissions" prior to this, this prevents it from happening again.