### PR TITLE
fix: check for permissions for stage channel

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -31,6 +31,12 @@ module.exports = {
 			// this also handles suppressing Quaver mid-track
 			if (newState.channel.type === 'GUILD_STAGE_VOICE' && newState.suppress) {
 				const permissions =	bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
+				// check for connect, speak permission for stage channel
+				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+					player.musicHandler.disconnect();
+					return;
+				}
 				if (!permissions.has(Permissions.STAGE_MODERATOR)) {
 					if (guildData.get(`${player.guildId}.always.enabled`)) {
 						guildData.set(`${player.guildId}.always.enabled`, false);

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -30,7 +30,7 @@ module.exports = {
 			// channel is a stage channel, and bot is suppressed
 			// this also handles suppressing Quaver mid-track
 			if (newState.channel.type === 'GUILD_STAGE_VOICE' && newState.suppress) {
-				const permissions =	bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
+				const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
 				// check for connect, speak permission for stage channel
 				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');


### PR DESCRIPTION
Fixes #183

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

This was supposed to come with #151
I added this check for Quaver to leave the stage channel if it lacks permissions to view the channel, connect, or speak in the stage channel.

As we all know, try catch catches the error "Missing Permissions" prior to this, this prevents it from happening again.