### PR TITLE
fix: check for player's pauseTimeout

### DIFF
--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -10,8 +10,10 @@ module.exports = class MusicHandler {
 	}
 
 	disconnect() {
-		clearTimeout(this.player.timeout);
-		clearTimeout(this.player.pauseTimeout);
+		if (this.player.pauseTimeout) {
+			clearTimeout(this.player.timeout);
+			clearTimeout(this.player.pauseTimeout);
+		}
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
 	}


### PR DESCRIPTION
# Issue still persists...
Should aim to fix #187

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Adds a check in musicHandler's `disconnect()` method

For Quaver to not clear pausetimeout if the player didn't set any, also fixes not exiting process that involves getting stuck on shuttingDown issues 
