### PR TITLE
fix: check for guild on interactions (Fixes #191)

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -55,13 +55,17 @@ module.exports = {
 			}
 			const failedPermissions = { user: [], bot: [] };
 			for (const perm of command.permissions.user) {
-				if (!interaction.channel.permissionsFor(interaction.member).has(perm)) {
-					failedPermissions.user.push(perm);
+				if (interaction.guildId) {
+					if (!interaction.channel.permissionsFor(interaction.member).has(perm)) {
+						failedPermissions.user.push(perm);
+					}
 				}
 			}
 			for (const perm of ['VIEW_CHANNEL', 'SEND_MESSAGES', ...command.permissions.bot]) {
-				if (!interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
-					failedPermissions.bot.push(perm);
+				if (interaction.guildId) {
+					if (!interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
+						failedPermissions.bot.push(perm);
+					}
 				}
 			}
 			if (failedPermissions.user.length > 0) {

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -54,19 +54,21 @@ module.exports = {
 				return;
 			}
 			const failedPermissions = { user: [], bot: [] };
-			for (const perm of command.permissions.user) {
-				if (interaction.guildId) {
+			if (interaction.guildId) {
+				for (const perm of command.permissions.user) {
 					if (!interaction.channel.permissionsFor(interaction.member).has(perm)) {
 						failedPermissions.user.push(perm);
 					}
 				}
-			}
-			for (const perm of ['VIEW_CHANNEL', 'SEND_MESSAGES', ...command.permissions.bot]) {
-				if (interaction.guildId) {
+				for (const perm of ['VIEW_CHANNEL', 'SEND_MESSAGES', ...command.permissions.bot]) {
 					if (!interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
 						failedPermissions.bot.push(perm);
 					}
 				}
+			}
+			else {
+				failedPermissions.user = command.permissions.user;
+				failedPermissions.bot = command.permissions.bot;
 			}
 			if (failedPermissions.user.length > 0) {
 				logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Command ${interaction.commandName} failed ${failedPermissions.user.length} user permission checks`, label: 'Quaver' });


### PR DESCRIPTION
Fixes #191

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

For me I see two or more ways of implementing this
1.
```js
				if (interaction.guildId) {
					if (!interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
						failedPermissions.bot.push(perm);
					}
				}
```
2.
```js
					if (interaction.guildId && !interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
						failedPermissions.bot.push(perm);
				}
```
3.
```js
					if (!interaction.guildId) return;
					if (!interaction.channel.permissionsFor(interaction.client.user.id).has(perm)) {
						failedPermissions.bot.push(perm);
				}
```

I chose the first one because it is much more readable than it already was with the 2nd one, 3rd one looks just as good as the first one, feel free to change it to your desired way of implementation.
Adds a check for Quaver to not crash and not check for permissions if the interaction came from a DM.	
I did not add `return;` for it to still send an interaction for some commands, like `/ping` and `/info`.