### PR TITLE
fix: update 247 channel when moved (Fixes #188)

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -36,6 +36,9 @@ module.exports = {
 					player.musicHandler.disconnect();
 					return;
 				}
+				if (guildData.get(`${player.guildId}.always.enabled`) && guildData.get(`${player.guildId}.always.channel`) !== newState.channelId) {
+					guildData.set(`${player.guildId}.always.channel`, newState.channelId);
+				}
 			}
 			// channel is a stage channel, and bot is suppressed
 			// this also handles suppressing Quaver mid-track
@@ -63,10 +66,10 @@ module.exports = {
 						logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
 					}
 				}
+				if (guildData.get(`${player.guildId}.always.enabled`) && guildData.get(`${player.guildId}.always.channel`) !== newState.channelId) {
+					guildData.set(`${player.guildId}.always.channel`, newState.channelId);
+				}
 				return;
-			}
-			if (guildData.get(`${player.guildId}.always.enabled`)) {
-				guildData.set(`${player.guildId}.always.channel`, newState.channelId);
 			}
 			// the new vc has no humans
 			if (newState.channel.members.filter(m => !m.user.bot).size < 1 && !guildData.get(`${player.guildId}.always.enabled`)) {


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Adds a check at the end of voice and stage channel checks for Quaver to update the 24/7 channel when it is moved.
