### PR TITLE
fix: create new MusicHandler for player on reconnect (Fixes #187)

### DIFF
--- a/events/music/connect.js
+++ b/events/music/connect.js
@@ -2,6 +2,7 @@ const { logger, guildData } = require('../../shared.js');
 const { getLocale } = require('../../functions.js');
 const { bot } = require('../../main.js');
 const { defaultLocale } = require('../../settings.json');
+const MusicHandler = require('../../classes/MusicHandler.js');
 
 module.exports = {
 	name: 'connect',
@@ -12,6 +13,7 @@ module.exports = {
 			if (guildData.get(`${guildId}.always.enabled`)) {
 				const guild = bot.guilds.cache.get(guildId);
 				const player = bot.music.createPlayer(guildId);
+				player.musicHandler = new MusicHandler(player);
 				player.queue.channel = guild.channels.cache.get(guildData.get(`${guildId}.always.text`));
 				const voice = guild.channels.cache.get(guildData.get(`${guildId}.always.channel`));
 				if (voice.type === 'GUILD_STAGE_VOICE' && !voice.stageInstance?.topic) {


### PR DESCRIPTION
(Fixes #187)

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Creates a new MusicHandler object for player on reconnecting to a voice channel from 24/7 feature.

#187 is related to this because there is no MusicHandler for player, Quaver cannot disconnect from the voice channel on shuttingDown because it is trying to call an Object that does not exist.