### PR TITLE
fix: revert unnecessary assignments (Fixes #207)

### DIFF
--- a/commands/loop.js
+++ b/commands/loop.js
@@ -16,7 +16,7 @@ module.exports = {
 				.setRequired(true)
 				.addChoice(getLocale(defaultLocale, 'CMD_LOOP_OPTION_TYPE_DISABLED'), 'disabled')
 				.addChoice(getLocale(defaultLocale, 'CMD_LOOP_OPTION_TYPE_TRACK'), 'track')
-				.addChoice(getLocale(defaultLocale, 'CMD_LOOP_OPTION_TYPE_QUEUE'), 'MISC_QUEUE')),
+				.addChoice(getLocale(defaultLocale, 'CMD_LOOP_OPTION_TYPE_QUEUE'), 'queue')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -35,7 +35,7 @@ module.exports = {
 				loop = LoopType.Song;
 				typeLocale = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'CMD_LOOP_OPTION_TYPE_TRACK');
 				break;
-			case 'MISC_QUEUE':
+			case 'queue':
 				loop = LoopType.Queue;
 				typeLocale = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'CMD_LOOP_OPTION_TYPE_QUEUE');
 				break;

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -8,7 +8,7 @@ const { guildData } = require('../shared.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
-		.setName('MISC_QUEUE')
+		.setName('queue')
 		.setDescription(getLocale(defaultLocale, 'CMD_QUEUE_DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -9,7 +9,7 @@ module.exports = {
 		.setDescription(getLocale(defaultLocale, 'CMD_REMOVE_DESCRIPTION'))
 		.addIntegerOption(option =>
 			option
-				.setName('MISC_POSITION')
+				.setName('position')
 				.setDescription(getLocale(defaultLocale, 'CMD_REMOVE_OPTION_POSITION'))
 				.setMinValue(1)
 				.setRequired(true)),
@@ -20,7 +20,7 @@ module.exports = {
 	},
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
-		const position = interaction.options.getInteger('MISC_POSITION');
+		const position = interaction.options.getInteger('position');
 		if (player.queue.tracks.length === 0) {
 			await interaction.replyHandler.localeError('CMD_REMOVE_EMPTY');
 			return;

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -93,7 +93,7 @@ module.exports = {
 		else if (interaction.isButton()) {
 			const type = interaction.customId.split('_')[0];
 			switch (type) {
-				case 'MISC_QUEUE': {
+				case 'queue': {
 					const player = interaction.client.music.players.get(interaction.guildId);
 					let pages, page;
 					if (player) {
@@ -141,7 +141,7 @@ module.exports = {
 					});
 					break;
 				}
-				case 'MISC_CANCEL':
+				case 'cancel':
 					if (interaction.customId.split('_')[1] !== interaction.user.id) {
 						await interaction.reply({
 							embeds: [


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Reverts some unnecessary changes made from https://github.com/ZapSquared/Quaver/commit/6bde4a11c613cf984a9c1fae2260a893aa38ce7e#

Why they're reverted? Which files?
1. `loop.js` should not have any changes.
2. `queue.js`'s command name should not have any changes.
3. `remove.js` integer option name should not have any changes.
4. `interactionCreate.js`'s switch case names should not have any changes.