### PR TITLE
fix: locate en-US strings at the right directory (Fixes #211)

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -156,7 +156,7 @@ function getLocale(language, string, ...vars) {
 function checkLocaleCompletion(language) {
 	let foreignStringCount = 0;
 	let stringCount = 0;
-	const stringFiles = fs.readdirSync('./locales/en.json').filter(file => file.endsWith('.json'));
+	const stringFiles = fs.readdirSync('./locales/en').filter(file => file.endsWith('.json'));
 	let missingStrings = [];
 	for (const file of stringFiles) {
 		const category = file.split('.')[0];


### PR DESCRIPTION
Fixes #211

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Removes unnecessary `.json` on require statement.
Because this prevents Quaver from locating its locale strings.