### PR TITLE
fix: end stage on disconnection if it exists (Fixes #126)

### DIFF
--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -31,7 +31,6 @@ module.exports = class MusicHandler {
 					logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
 				}
 			}
-			return;
 		}
 	}
 

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -11,7 +11,6 @@ module.exports = class MusicHandler {
 	async disconnect() {
 		const { bot } = require('../main.js');
 		const voiceChannel = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId);
-		const { oldVoiceChannel } = require('../events/voiceStateUpdate.js');
 		clearTimeout(this.player.timeout);
 		clearTimeout(this.player.pauseTimeout);
 		this.player.disconnect();
@@ -33,25 +32,6 @@ module.exports = class MusicHandler {
 				}
 			}
 			return;
-		}
-		if (oldVoiceChannel?.type === 'GUILD_STAGE_VOICE') {
-			const oldVoicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(oldVoiceChannel.id).permissionsFor(bot.user.id);
-			if (!oldVoicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
-				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
-				return;
-			}
-			if (!oldVoicePerms.has(Permissions.STAGE_MODERATOR)) {
-				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
-				return;
-			}
-			if (oldVoiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
-				try {
-					await oldVoiceChannel.stageInstance.delete();
-				}
-				catch (err) {
-					logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
-				}
-			}
 		}
 	}
 

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -26,7 +26,7 @@ module.exports = class MusicHandler {
 				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
 				return;
 			}
-			if (voiceChannel.stageInstance?.topic) {
+			if (voiceChannel.stageInstance?.topic?.includes(getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'))) {
 				try {
 					await voiceChannel.stageInstance.delete();
 				}
@@ -46,7 +46,7 @@ module.exports = class MusicHandler {
 				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
 				return;
 			}
-			if (oldVoiceChannel.stageInstance?.topic) {
+			if (oldVoiceChannel.stageInstance?.topic?.includes(getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'))) {
 				try {
 					await oldVoiceChannel.stageInstance.delete();
 				}

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -10,11 +10,11 @@ module.exports = class MusicHandler {
 
 	async disconnect() {
 		const { bot } = require('../main.js');
-		const voiceChannel = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId);
 		clearTimeout(this.player.timeout);
 		clearTimeout(this.player.pauseTimeout);
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
+		const voiceChannel = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
 			const permissions = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
 			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -19,11 +19,9 @@ module.exports = class MusicHandler {
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
 			const voicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
 			if (!voicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
-				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
 				return;
 			}
 			if (!voicePerms.has(Permissions.STAGE_MODERATOR)) {
-				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
 				return;
 			}
 			if (voiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -26,7 +26,7 @@ module.exports = class MusicHandler {
 				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
 				return;
 			}
-			if (voiceChannel.stageInstance?.topic?.includes(getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'))) {
+			if (voiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
 				try {
 					await voiceChannel.stageInstance.delete();
 				}
@@ -46,7 +46,7 @@ module.exports = class MusicHandler {
 				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
 				return;
 			}
-			if (oldVoiceChannel.stageInstance?.topic?.includes(getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC'))) {
+			if (oldVoiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
 				try {
 					await oldVoiceChannel.stageInstance.delete();
 				}

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -8,12 +8,35 @@ module.exports = class MusicHandler {
 		this.player = player;
 	}
 
-	disconnect() {
+	async disconnect() {
 		const { bot } = require('../main.js');
+		const voiceChannel = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId);
+		const { oldVoiceChannel } = require('../events/voiceStateUpdate.js');
 		clearTimeout(this.player.timeout);
 		clearTimeout(this.player.pauseTimeout);
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
+		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
+			if (voiceChannel.stageInstance?.topic) {
+				try {
+					await voiceChannel.stageInstance.delete();
+				}
+				catch (err) {
+					logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
+				}
+			}
+			return;
+		}
+		if (oldVoiceChannel.type === 'GUILD_STAGE_VOICE') {
+			if (oldVoiceChannel.stageInstance?.topic) {
+				try {
+					await oldVoiceChannel.stageInstance.delete();
+				}
+				catch (err) {
+					logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
+				}
+			}
+		}
 	}
 
 	sendDataConstructor(data, embedExtras, error) {

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -1,4 +1,4 @@
-const { MessageEmbed } = require('discord.js');
+const { MessageEmbed, Permissions } = require('discord.js');
 const { guildData, logger } = require('../shared.js');
 const { getLocale } = require('../functions.js');
 const { defaultLocale, defaultColor } = require('../settings.json');
@@ -17,6 +17,15 @@ module.exports = class MusicHandler {
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
+			const voicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
+			if (!voicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+				return;
+			}
+			if (!voicePerms.has(Permissions.STAGE_MODERATOR)) {
+				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
+				return;
+			}
 			if (voiceChannel.stageInstance?.topic) {
 				try {
 					await voiceChannel.stageInstance.delete();
@@ -28,6 +37,15 @@ module.exports = class MusicHandler {
 			return;
 		}
 		if (oldVoiceChannel.type === 'GUILD_STAGE_VOICE') {
+			const oldVoicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(oldVoiceChannel.id).permissionsFor(bot.user.id);
+			if (!oldVoicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+				return;
+			}
+			if (!oldVoicePerms.has(Permissions.STAGE_MODERATOR)) {
+				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
+				return;
+			}
 			if (oldVoiceChannel.stageInstance?.topic) {
 				try {
 					await oldVoiceChannel.stageInstance.delete();

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -16,11 +16,11 @@ module.exports = class MusicHandler {
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
-			const voicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
-			if (!voicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+			const permissions = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
+			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 				return;
 			}
-			if (!voicePerms.has(Permissions.STAGE_MODERATOR)) {
+			if (!permissions.has(Permissions.STAGE_MODERATOR)) {
 				return;
 			}
 			if (voiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -36,7 +36,7 @@ module.exports = class MusicHandler {
 			}
 			return;
 		}
-		if (oldVoiceChannel.type === 'GUILD_STAGE_VOICE') {
+		if (oldVoiceChannel?.type === 'GUILD_STAGE_VOICE') {
 			const oldVoicePerms = bot.guilds.cache.get(this.player.guildId).channels.cache.get(oldVoiceChannel.id).permissionsFor(bot.user.id);
 			if (!oldVoicePerms.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 				await this.player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');

--- a/commands/disconnect.js
+++ b/commands/disconnect.js
@@ -19,7 +19,7 @@ module.exports = {
 			return;
 		}
 		const player = interaction.client.music.players.get(interaction.guildId);
-		player.musicHandler.disconnect();
+		await player.musicHandler.disconnect();
 		await interaction.replyHandler.locale('CMD_DISCONNECT_SUCCESS');
 	},
 };

--- a/commands/play.js
+++ b/commands/play.js
@@ -95,7 +95,7 @@ module.exports = {
 			// that kid left while we were busy bruh
 			if (!interaction.member.voice.channelId) {
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
-				player.musicHandler.disconnect();
+				await player.musicHandler.disconnect();
 				return;
 			}
 			if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance?.topic) {

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -236,7 +236,7 @@ module.exports = {
 						await player.connect(interaction.member.voice.channelId, { deafened: true });
 						// that kid left while we were busy bruh
 						if (!interaction.member.voice.channelId) {
-							player.musicHandler.disconnect();
+							await player.musicHandler.disconnect();
 							await interaction.editReply({
 								embeds: [
 									new MessageEmbed()

--- a/events/music/queueFinish.js
+++ b/events/music/queueFinish.js
@@ -14,10 +14,10 @@ module.exports = {
 		if (queue.player.timeout) {
 			clearTimeout(queue.player.timeout);
 		}
-		queue.player.timeout = setTimeout(async p => {
+		queue.player.timeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.musicHandler.locale('MUSIC_INACTIVITY');
-			await p.musicHandler.disconnect();
+			p.musicHandler.disconnect();
 		}, 1800000, queue.player);
 		queue.player.musicHandler.send(`${getLocale(guildData.get(`${queue.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(guildData.get(`${queue.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`);
 	},

--- a/events/music/queueFinish.js
+++ b/events/music/queueFinish.js
@@ -14,10 +14,10 @@ module.exports = {
 		if (queue.player.timeout) {
 			clearTimeout(queue.player.timeout);
 		}
-		queue.player.timeout = setTimeout(p => {
+		queue.player.timeout = setTimeout(async p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.musicHandler.locale('MUSIC_INACTIVITY');
-			p.musicHandler.disconnect();
+			await p.musicHandler.disconnect();
 		}, 1800000, queue.player);
 		queue.player.musicHandler.send(`${getLocale(guildData.get(`${queue.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(guildData.get(`${queue.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`);
 	},

--- a/events/music/trackEnd.js
+++ b/events/music/trackEnd.js
@@ -13,7 +13,7 @@ module.exports = {
 		if (bot.guilds.cache.get(queue.player.guildId).channels.cache.get(queue.player.channelId).members?.filter(m => !m.user.bot).size < 1 && !guildData.get(`${queue.player.guildId}.always.enabled`)) {
 			logger.info({ message: `[G ${queue.player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
 			queue.player.musicHandler.locale('MUSIC_ALONE');
-			queue.player.musicHandler.disconnect();
+			await queue.player.musicHandler.disconnect();
 			return;
 		}
 	},

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -94,10 +94,10 @@ module.exports = {
 				if (player.pauseTimeout) {
 					clearTimeout(player.pauseTimeout);
 				}
-				player.pauseTimeout = setTimeout(async p => {
+				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 					p.musicHandler.locale('MUSIC_INACTIVITY');
-					await p.musicHandler.disconnect();
+					p.musicHandler.disconnect();
 				}, 300000, player);
 				await player.musicHandler.send(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
 			}
@@ -144,10 +144,10 @@ module.exports = {
 		if (player.pauseTimeout) {
 			clearTimeout(player.pauseTimeout);
 		}
-		player.pauseTimeout = setTimeout(async p => {
+		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.musicHandler.locale('MUSIC_INACTIVITY');
-			await p.musicHandler.disconnect();
+			p.musicHandler.disconnect();
 		}, 300000, player);
 		await player.musicHandler.send(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
 	},

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -26,7 +26,7 @@ module.exports = {
 					guildData.set(`${player.guildId}.always.enabled`, false);
 				}
 				await player.musicHandler.locale('MUSIC_FORCED');
-				player.musicHandler.disconnect();
+				await player.musicHandler.disconnect();
 				return;
 			}
 			// channel is a voice channel
@@ -35,7 +35,7 @@ module.exports = {
 				const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(bot.user.id);
 				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
-					player.musicHandler.disconnect();
+					await player.musicHandler.disconnect();
 					return;
 				}
 				if (guildData.get(`${player.guildId}.always.enabled`) && guildData.get(`${player.guildId}.always.channel`) !== newState.channelId) {
@@ -49,7 +49,7 @@ module.exports = {
 				// check for connect, speak permission for stage channel
 				if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 					await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
-					player.musicHandler.disconnect();
+					await player.musicHandler.disconnect();
 					return;
 				}
 				if (!permissions.has(Permissions.STAGE_MODERATOR)) {
@@ -57,7 +57,7 @@ module.exports = {
 						guildData.set(`${player.guildId}.always.enabled`, false);
 					}
 					await player.musicHandler.locale('MUSIC_FORCED_STAGE');
-					player.musicHandler.disconnect();
+					await player.musicHandler.disconnect();
 					return;
 				}
 				await newState.setSuppressed(false);
@@ -83,7 +83,7 @@ module.exports = {
 					}
 					logger.info({ message: `[G ${player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
 					await player.musicHandler.locale('MUSIC_ALONE_MOVED');
-					player.musicHandler.disconnect();
+					await player.musicHandler.disconnect();
 					return;
 				}
 				// avoid pauseTimeout if 24/7 is enabled
@@ -94,10 +94,10 @@ module.exports = {
 				if (player.pauseTimeout) {
 					clearTimeout(player.pauseTimeout);
 				}
-				player.pauseTimeout = setTimeout(p => {
+				player.pauseTimeout = setTimeout(async p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 					p.musicHandler.locale('MUSIC_INACTIVITY');
-					p.musicHandler.disconnect();
+					await p.musicHandler.disconnect();
 				}, 300000, player);
 				await player.musicHandler.send(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
 			}
@@ -136,7 +136,7 @@ module.exports = {
 		if (!player.queue.current || !player.playing && !player.paused) {
 			logger.info({ message: `[G ${player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
 			player.musicHandler.locale('MUSIC_ALONE');
-			player.musicHandler.disconnect();
+			await player.musicHandler.disconnect();
 			return;
 		}
 		await player.pause();
@@ -144,10 +144,10 @@ module.exports = {
 		if (player.pauseTimeout) {
 			clearTimeout(player.pauseTimeout);
 		}
-		player.pauseTimeout = setTimeout(p => {
+		player.pauseTimeout = setTimeout(async p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.musicHandler.locale('MUSIC_INACTIVITY');
-			p.musicHandler.disconnect();
+			await p.musicHandler.disconnect();
 		}, 300000, player);
 		await player.musicHandler.send(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
 	},

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -19,8 +19,6 @@ module.exports = {
 			}
 			// disconnected
 			if (!newState.channelId || !newState.channel?.members.find(m => m.user.id === bot.user.id)) {
-				const oldVoiceChannel = oldState.channel;
-				module.exports.oldVoiceChannel = oldVoiceChannel;
 				logger.info({ message: `[G ${player.guildId}] Cleaning up`, label: 'Quaver' });
 				if (guildData.get(`${player.guildId}.always.enabled`)) {
 					guildData.set(`${player.guildId}.always.enabled`, false);

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -25,7 +25,9 @@ module.exports = {
 				}
 				await player.musicHandler.locale('MUSIC_FORCED');
 				await player.musicHandler.disconnect();
+				// channel was a stage channel, and bot is unsuppressed
 				if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
+					// check for connect, speak permission for voice channel
 					const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(oldState.channelId).permissionsFor(bot.user.id);
 					if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
 						await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -25,6 +25,25 @@ module.exports = {
 				}
 				await player.musicHandler.locale('MUSIC_FORCED');
 				await player.musicHandler.disconnect();
+				if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
+					const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(oldState.channelId).permissionsFor(bot.user.id);
+					if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {
+						await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+						return;
+					}
+					if (!permissions.has(Permissions.STAGE_MODERATOR)) {
+						await player.musicHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
+						return;
+					}
+					if (oldState.channel.stageInstance?.topic === getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
+						try {
+							await oldState.channel.stageInstance.delete();
+						}
+						catch (err) {
+							logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
+						}
+					}
+				}
 				return;
 			}
 			// channel is a voice channel

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -26,7 +26,7 @@ module.exports = {
 				await player.musicHandler.locale('MUSIC_FORCED');
 				await player.musicHandler.disconnect();
 				// channel was a stage channel, and bot is unsuppressed
-				if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
+				if (oldState.channel.type === 'GUILD_STAGE_VOICE' && !oldState.suppress) {
 					// check for connect, speak permission for voice channel
 					const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(oldState.channelId).permissionsFor(bot.user.id);
 					if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -19,6 +19,8 @@ module.exports = {
 			}
 			// disconnected
 			if (!newState.channelId || !newState.channel?.members.find(m => m.user.id === bot.user.id)) {
+				const oldVoiceChannel = oldState.channel;
+				module.exports.oldVoiceChannel = oldVoiceChannel;
 				logger.info({ message: `[G ${player.guildId}] Cleaning up`, label: 'Quaver' });
 				if (guildData.get(`${player.guildId}.always.enabled`)) {
 					guildData.set(`${player.guildId}.always.enabled`, false);

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -25,7 +25,7 @@ module.exports = {
 				}
 				await player.musicHandler.locale('MUSIC_FORCED');
 				await player.musicHandler.disconnect();
-				// channel was a stage channel, and bot is unsuppressed
+				// channel was a stage channel, and bot was unsuppressed
 				if (oldState.channel.type === 'GUILD_STAGE_VOICE' && !oldState.suppress) {
 					// check for connect, speak permission for voice channel
 					const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(oldState.channelId).permissionsFor(bot.user.id);

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ async function shuttingDown(eventType, err) {
 				fileBuffer.push(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'MISC_QUEUE')}:`);
 				fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
 			}
-			player.musicHandler.disconnect();
+			await player.musicHandler.disconnect();
 			const botChannelPerms = bot.guilds.cache.get(player.guildId).channels.cache.get(player.queue.channel.id).permissionsFor(bot.user.id);
 			if (!botChannelPerms.has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) { continue; }
 			await player.queue.channel.send({


### PR DESCRIPTION
Fixes #126
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Ends the stage when Quaver gets disconnected from a Stage Channel that has a Stage Instance active.

This is not a full implementation since I excluded one condition. 

## What is the difference between `voiceChannel`  and `oldState`
- `voiceChannel` is for fetching the cache of the guild and channels for the active player and direct interactions only.
e.g. User uses the `/disconnect` command, disconnects Quaver and ends the stage instance if one was present.

- `oldState` channel, should only handle ending stage on disconnections for `voiceStateUpdate` only. (**UPDATE**: Superseded by the first way of implementation.)
e.g. User manually disconnects Quaver, counts as a `voiceStateUpdate`, the stage instance will be deleted if one was present.

## Why there is an optional chaining operator here?
```js
		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
```

I think it is highly likely on some `disconnect()` calls absurd or not, the `type` in `voiceChannel` ~~or `oldVoiceChannel`~~ becomes undefined, so, just making sure it doesn't crash just because of that, and instead do nothing, for it is supposed to do nothing at any other conditions.

## Why `await` and `async`?
I think try catch will not be able to work without it.

## Why `try catch`?
In the most absurd conditions, try catch will prevent them from crashing Quaver.

## Why not just `voiceChannel` alone and not include `oldVoiceChannel`?
If Quaver gets *manually* disconnected from the stage channel, not from the `/disconnect` command, Quaver will not be able to end the stage since the handler for that is `voiceStateUpdate`'s `oldState`
**UPDATE**: Superseded by the first way of implementation.

## Why you did it like this?
```js
				const oldVoiceChannel = oldState.channel;
				module.exports.oldVoiceChannel = oldVoiceChannel;
```
Honestly, I haven't thought of a better way where to put those statements, so... Looking forward for a better way on where to put that, maybe on top, or suggest changes.
**UPDATE**: Superseded by the first way of implementation. After the review, first way of implementation was actually better. Don't do this, it is bad.

## What was that one condition you excluded making this an incomplete implementation? Why is it excluded?
The condition is: 
`If Quaver gets moved to another voice/stage channel, delete the previous stage instance made in the previous stage channel if present and its stage topic is the locale string MUSIC_STAGE_TOPIC.`
If Quaver gets moved from voice/stage channel to channel with this same condition from the user multiple times, Discord's ratelimiting will hinder its functionality.

If you wanted this to be included again and have a better alternative implementation, suggest.

## Why the statements are below `bot.music.destroyPlayer`?
Avoiding conflicts with `voiceStateUpdate`.
Deleting a stage instance counts as a `voiceStateUpdate`, for that reason, we destroy the player first *before* deleting the stage instance so that "`voiceStateUpdate` from the stage instance delete" will just halt at `if (!player) return;`, touching nothing else, not wasting any more resources.


## Why there are permission checks before deleting a stage instance?
These are needed to be handled If somehow the user abruptly just disabled the said permissions for Quaver while the following conditions were met. Otherwise, an error of `DiscordAPIError: Missing Permissions or Missing Access` would occur in the console.

## Why not suppressing Quaver again first if unsuppressed, then delete the stage instance?
1. I want to reduce contributors of ratelimits, the more of them the faster Quaver gets ratelimited.
2. It is redundant and a waste of resources to suppress Quaver again since ending a stage takes them all in one go.

## Why only delete stage instances that contains the topic: String of locale `MUSIC_STAGE_TOPIC`
1. I want to reduce contributors of ratelimits, the more of them the faster Quaver gets ratelimited.
2. For to not waste anymore resources deleting stage instances Quaver doesn't even own.

## Why `voiceChannel` do not have any locale calls on permission checks but `oldState` has?
`voiceChannel`'s locale calls are handled by `voiceStateUpdate` already while
`oldState` does not have any so they're specific to that statement. Otherwise, if `voiceChannel` had locale calls, everytime a permission check in `voiceStateUpdate` triggers, two embeds would pop up and prompt for the user.

### Testing: Tested