### PR TITLE
refactor: check the right channel (Fixes #198)

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -117,7 +117,7 @@ module.exports = {
 		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : '' }, ...extras);
 		if (!started) { await player.queue.start(); }
 		const state = interaction.guild.members.cache.get(interaction.client.user.id).voice;
-		if (state.channel.type === 'GUILD_STAGE_VOICE' && state.suppress) {
+		if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && state.suppress) {
 			await state.setSuppressed(false);
 		}
 	},


### PR DESCRIPTION
Fixes #198

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

I did this because `state.channel.type` is returning always `null` for some reason