### PR TITLE
fix: add necessary optional chaining operator (Fixes #223)

### DIFF
--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -17,7 +17,7 @@ module.exports = class MusicHandler {
 		clearTimeout(this.player.pauseTimeout);
 		this.player.disconnect();
 		bot.music.destroyPlayer(this.player.guildId);
-		const voiceChannel = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId);
+		const voiceChannel = bot.guilds.cache.get(this.player.guildId)?.channels.cache.get(this.player.channelId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
 			const permissions = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
 			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) return;


### PR DESCRIPTION
Fixes #223

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Adds an optional chaining operator before checking channels, return as undefined.
For Quaver to not crash when it leaves a guild from the guildDelete event.