### PR TITLE
fix: add necessary optional chaining operator (Fixes #225)

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -24,7 +24,7 @@ module.exports = {
 				const success = await player.musicHandler.locale('MUSIC_FORCED');
 				await player.musicHandler.disconnect();
 				// channel was a stage channel, and bot was unsuppressed
-				if (oldState.channel.type === 'GUILD_STAGE_VOICE' && !oldState.suppress) {
+				if (oldState.channel?.type === 'GUILD_STAGE_VOICE' && !oldState.suppress) {
 					// check for connect, speak permission for voice channel
 					const permissions = bot.guilds.cache.get(guild.id).channels.cache.get(oldState.channelId).permissionsFor(bot.user.id);
 					if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) {


### PR DESCRIPTION
Fixes #225

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Adds an optional chaining operator before oldState channel type, return as undefined.
For Quaver to not crash when it leaves a guild from the guildDelete event.