### PR TITLE
fix: check for bot's existence when disconnected (Fixes #227)

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -114,8 +114,7 @@ module.exports = {
 		const endPosition = firstPosition + tracks.length - 1;
 
 		// that kid disconnected me while we were busy bruh
-		const voiceChannel = interaction.member.voice.channel;
-		if (!voiceChannel.members.has(interaction.client.user.id) && interaction.member.voice.channelId) {
+		if (!interaction.member.voice.channel.members.filter(m => m.id === interaction.client.user.id)) {
 			await player.musicHandler.disconnect();
 			await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 			return;

--- a/commands/play.js
+++ b/commands/play.js
@@ -113,6 +113,13 @@ module.exports = {
 		const firstPosition = insert ? 1 : player.queue.tracks.length + 1;
 		const endPosition = firstPosition + tracks.length - 1;
 
+		// that kid disconnected me while we were busy bruh
+		const voiceChannel = interaction.member.voice.channel;
+		if (!voiceChannel.members.has(interaction.client.user.id) && interaction.member.voice.channelId) {
+			await player.musicHandler.disconnect();
+			await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+			return;
+		}
 		player.queue.add(tracks, { requester: interaction.user.id, next: insert });
 
 		const started = player.playing || player.paused;

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -239,7 +239,7 @@ module.exports = {
 						msg = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_ADDED_MULTI', resolvedTracks.length, getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_SEARCH'), '');
 					}
 					// that kid disconnected me while we were busy bruh
-					const voiceChannel = interaction.member?.voice.channel;
+					const voiceChannel = interaction.member.voice.channel;
 					if (!voiceChannel.members.has(interaction.client.user.id) && interaction.member.voice.channelId) {
 						await player.musicHandler.disconnect();
 						await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -238,6 +238,13 @@ module.exports = {
 					else {
 						msg = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_ADDED_MULTI', resolvedTracks.length, getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_SEARCH'), '');
 					}
+					// that kid disconnected me while we were busy bruh
+					const voiceChannel = interaction.member?.voice.channel;
+					if (!voiceChannel.members.has(interaction.client.user.id) && interaction.member.voice.channelId) {
+						await player.musicHandler.disconnect();
+						await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+						return;
+					}
 					player.queue.add(resolvedTracks, { requester: interaction.user.id });
 					const started = player.playing || player.paused;
 					await interaction.replyHandler.reply(msg, { footer: started ? `${getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : '', components: [] });


### PR DESCRIPTION
Fixes #227

## Supposed to add a check for `search` and `play` 
Review #229 instead if only search needs to be handled and not both of them.

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

I added a check for Quaver to cancel the interaction if the user just abruptly disconnected Quaver while it is busy queuing with search.

I placed the check right before it adds the tracks because I think that's the optimal place to put it.

Please check for any more oversights, like missed optional chaining operators on the set conditions.

Test: Tested
- Will add the tracks if the condition is not met (searching normally)
- Edit the message with interaction cancelled by x if the user disconnected Quaver while it is busy with search.