### PR TITLE
fix: only join channel once tracks are loaded with search (Fixes #227)

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -238,7 +238,9 @@ module.exports = {
 
 					const firstPosition = player.queue.tracks.length + 1;
 					const endPosition = firstPosition + resolvedTracks.length - 1;
+
 					player.queue.add(resolvedTracks, { requester: interaction.user.id });
+
 					const started = player.playing || player.paused;
 					await interaction.replyHandler.reply(msg, { footer: started ? `${getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : '', components: [] });
 					if (!started) { await player.queue.start(); }


### PR DESCRIPTION
Fixes #227

### Only one of these solutions should be reviewed or merged.
### Alternative solution involving a check: #229

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

Instead of joining the channel while search is queuing up tracks, this change will make Quaver only join the voice/stage channel once the tracks are loaded, with that, we don't need to implement anymore checks for when it gets disconnected while queuing.