### PR TITLE
refactor: reimplement search to use ReplyHandler.locale

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -231,16 +231,18 @@ module.exports = {
 					}
 					const firstPosition = player.queue.tracks.length + 1;
 					const endPosition = firstPosition + resolvedTracks.length - 1;
-					let msg;
+					let msg, extras = [];
 					if (resolvedTracks.length === 1) {
-						msg = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_ADDED', resolvedTracks[0].info.title, resolvedTracks[0].info.uri);
+						msg = 'MUSIC_QUEUE_ADDED';
+						extras = [resolvedTracks[0].info.title, resolvedTracks[0].info.uri];
 					}
 					else {
-						msg = getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_QUEUE_ADDED_MULTI', resolvedTracks.length, getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_SEARCH'), '');
+						msg = 'MUSIC_QUEUE_ADDED_MULTI';
+						extras = [resolvedTracks.length, getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MUSIC_SEARCH'), ''] ;
 					}
 					player.queue.add(resolvedTracks, { requester: interaction.user.id });
 					const started = player.playing || player.paused;
-					await interaction.replyHandler.reply(msg, { footer: started ? `${getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : '', components: [] });
+					await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : '', components: [] }, ...extras);
 					if (!started) { await player.queue.start(); }
 					const state = interaction.guild.members.cache.get(interaction.client.user.id).voice;
 					if (state.channel.type === 'GUILD_STAGE_VOICE' && state.suppress) {


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

This reimplements search to use a similar approach on `/play`, since play is using MusicHandler.locale, I thought search would be able to use that feature as well.