### PR TITLE
refactor: add client parameter for MusicHandler

### DIFF
--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -4,7 +4,8 @@ const { getLocale } = require('../functions.js');
 const { defaultLocale, defaultColor } = require('../settings.json');
 
 module.exports = class MusicHandler {
-	constructor(player) {
+	constructor(client, player) {
+		this.client = client;
 		this.player = player;
 	}
 

--- a/classes/MusicHandler.js
+++ b/classes/MusicHandler.js
@@ -13,14 +13,13 @@ module.exports = class MusicHandler {
 	 * Disconnects and cleans up the player.
 	 */
 	async disconnect() {
-		const { bot } = require('../main.js');
 		clearTimeout(this.player.timeout);
 		clearTimeout(this.player.pauseTimeout);
 		this.player.disconnect();
-		bot.music.destroyPlayer(this.player.guildId);
-		const voiceChannel = bot.guilds.cache.get(this.player.guildId)?.channels.cache.get(this.player.channelId);
+		this.client.music.destroyPlayer(this.player.guildId);
+		const voiceChannel = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(this.player.channelId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
-			const permissions = bot.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(bot.user.id);
+			const permissions = this.client.guilds.cache.get(this.player.guildId).channels.cache.get(this.player.channelId).permissionsFor(this.client.user.id);
 			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) return;
 			if (!permissions.has(Permissions.STAGE_MODERATOR)) return;
 			if (voiceChannel.stageInstance?.topic === getLocale(guildData.get(`${this.player.guildId}.locale`) ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
@@ -65,11 +64,10 @@ module.exports = class MusicHandler {
 	 * @returns {Message|APIMessage|boolean} - The message that was sent.
 	 */
 	async send(data, embedExtras, error) {
-		const { bot } = require('../main.js');
 		const sendData = this.sendDataConstructor(data, embedExtras, error);
 		const channel = this.player.queue.channel;
-		if (!channel.permissionsFor(bot.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) return false;
-		if (bot.guilds.cache.get(this.player.guildId).members.cache.get(bot.user.id).isCommunicationDisabled()) return false;
+		if (!channel.permissionsFor(this.client.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) return false;
+		if (this.client.guilds.cache.get(this.player.guildId).members.cache.get(this.client.user.id).isCommunicationDisabled()) return false;
 		try {
 			return await channel.send(sendData);
 		}

--- a/commands/play.js
+++ b/commands/play.js
@@ -91,7 +91,7 @@ module.exports = {
 		let player = interaction.client.music.players.get(interaction.guildId);
 		if (!player?.connected) {
 			player = interaction.client.music.createPlayer(interaction.guildId);
-			player.musicHandler = new MusicHandler(player);
+			player.musicHandler = new MusicHandler(interaction.client, player);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// that kid left while we were busy bruh

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -219,7 +219,7 @@ module.exports = {
 					}
 					if (!player?.connected) {
 						player = interaction.client.music.createPlayer(interaction.guildId);
-						player.musicHandler = new MusicHandler(player);
+						player.musicHandler = new MusicHandler(interaction.client, player);
 						player.queue.channel = interaction.channel;
 						await player.connect(interaction.member.voice.channelId, { deafened: true });
 						// that kid left while we were busy bruh

--- a/events/music/connect.js
+++ b/events/music/connect.js
@@ -13,7 +13,7 @@ module.exports = {
 			if (guildData.get(`${guildId}.always.enabled`)) {
 				const guild = bot.guilds.cache.get(guildId);
 				const player = bot.music.createPlayer(guildId);
-				player.musicHandler = new MusicHandler(player);
+				player.musicHandler = new MusicHandler(bot, player);
 				player.queue.channel = guild.channels.cache.get(guildData.get(`${guildId}.always.text`));
 				const voice = guild.channels.cache.get(guildData.get(`${guildId}.always.channel`));
 				if (voice.type === 'GUILD_STAGE_VOICE' && !voice.stageInstance?.topic) {


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

Adds a `client` parameter to MusicHandler constructor and using it instead, for to minimize imports of `bot`.