### PR TITLE
refactor: rename permissions to use parenthetical plurals

### DIFF
--- a/locales/en/cmd.json
+++ b/locales/en/cmd.json
@@ -11,7 +11,7 @@
 	"BASSBOOST_DISABLED": "Bass boost **disabled**",
 	"BIND_DESCRIPTION": "Change the text channel used by Quaver to send messages automatically.",
 	"BIND_OPTION_CHANNEL": "The text channel to bind to.",
-	"BIND_NO_PERMISSIONS": "I do not have sufficient permissions in <#%1>.",
+	"BIND_NO_PERMISSIONS": "I do not have sufficient permission(s) in <#%1>.",
 	"BIND_SUCCESS": "Bound to <#%1>",
 	"CLEAR_DESCRIPTION": "Clear the queue.",
 	"CLEAR_EMPTY": "There are no tracks in the queue to clear.",

--- a/locales/en/discord.json
+++ b/locales/en/discord.json
@@ -1,6 +1,6 @@
 {
-	"USER_MISSING_PERMISSIONS": "You are missing permissions: %1",
-	"BOT_MISSING_PERMISSIONS": "I am missing permissions: %1",
+	"USER_MISSING_PERMISSIONS": "You are missing permission(s): %1",
+	"BOT_MISSING_PERMISSIONS": "I am missing permission(s): %1",
 	"BOT_MISSING_PERMISSIONS_BASIC": "I need to be able to connect and speak in the voice channel.",
 	"BOT_MISSING_PERMISSIONS_STAGE": "I need to be a stage moderator in the stage channel.",
 	"BOT_TIMED_OUT": "I am currently timed out.",


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

`permissions` should be `permission(s)` as indication that the `permission` may be a plural or a singular.