### PR TITLE
fix: use await on interaction update

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -136,7 +136,7 @@ module.exports = {
 						.setStyle('SECONDARY')
 						.setLabel(getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'MISC_REFRESH'));
 					try {
-						interaction.update({
+						await interaction.update({
 							embeds: original.embeds,
 							components: original.components,
 						});


### PR DESCRIPTION
Fixes #250

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [x] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

`Try/catch` would be useless without using `await`
